### PR TITLE
fix: bloating of sdists by setuptools-scm

### DIFF
--- a/.readthedocs_conda_env.yml
+++ b/.readthedocs_conda_env.yml
@@ -8,6 +8,7 @@ dependencies:
   - sphinx=3.0.4
   - pytest
   - pytest-cov
+  - importlib-metadata
   - numpy
   - pybedtools
   - matplotlib-base

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-exclude trtools/testsupport/sample_vcfs
-exclude trtools/testsupport/sample_regions
-exclude trtools/testsupport/sample_stats
-include LICENSE.txt
-

--- a/PUBLISHING.rst
+++ b/PUBLISHING.rst
@@ -43,18 +43,19 @@ Once changes have been made to develop that are ready to be published, first cho
 Then go through the steps of merging the changes into the master branch:
 
 #. Run :code:`pytest` and make sure all the tests pass. Then run :code:`./test/cmdline_tests.sh` and make sure those tests pass.
+#. Update the version number listed in the :code:`pyproject.toml` file.
 #. Change the 'Unreleased Changes' section of :code:`RELEASE_NOTES.rst` to the new version number.
 #. Check if any changes have been made that have not yet been documented in the release notes. If so, document them.
-#. Submit a pull request from develop into master on the github webiste.
+#. Submit a pull request from develop into master on the github website.
 #. If the code review checks pass, merge the pull request.
 #. Tag the merge commit with the package version in vX.Y.Z format. (For more details on tagging, see `below`)
 
 Then go through the steps of publishing the changed code to PyPI:
 
-1. :code:`cd` into the root of your clone of the trtools repo, checkout master and pull the latest change. Note that the most recent commit *must* be tagged.
+1. :code:`cd` into the root of your clone of the trtools repo, checkout master and pull the latest change. The most recent commit should be tagged.
 2. Run :code:`rm -rf build dist *.egg-info` to make sure all previous build artifacts are removed
 3. Run :code:`python -m build` to build the package with the version number you just tagged. (Note: you might need to install ``build`` first.)
-5. Run :code:`twine upload dist/*` to upload the distribution to PyPI
+4. Run :code:`twine upload dist/*` to upload the distribution to PyPI
 
 Lastly, the change needs to be published to bioconda.
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,3 +1,10 @@
+5.1.1
+-----
+
+Bug fixes:
+
+* Remove stray files from source distribution
+
 5.1.0
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "trtools"
+version = "5.1.1"
 authors = [
     {name = "Melissa Gymrek", email = "mgymrek@ucsd.edu"},
     {name = "Gymrek Lab"},
@@ -20,6 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
+    "importlib-metadata", # required as long as we support py<3.8
     "cyvcf2",
     "matplotlib",
     "numpy",
@@ -31,16 +33,13 @@ dependencies = [
     "statsmodels",
     "pyfaidx",
 ]
-dynamic = ["version"]
 
 [tool.setuptools]
-packages = ["trtools"]
 script-files = ["trtools/testsupport/test_trtools.sh", "scripts/trtools_prep_beagle_vcf.sh"]
 license-files = ["LICENSE.txt"]
 
-[tool.setuptools_scm]
-# generated automatically by setuptools when running pip install -e or python -m build
-version_file = "trtools/version.py"
+[tool.setuptools.packages.find]
+exclude = ["trtools.testsupport.*", "doc"]
 
 [project.scripts]
 dumpSTR = "trtools.dumpSTR:run"

--- a/trtools/__init__.py
+++ b/trtools/__init__.py
@@ -1,4 +1,10 @@
 try:
-    from .version import __version__
-except ModuleNotFoundError:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # handles py3.7, since importlib.metadata was introduced in py3.8
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     __version__ = "unknown"


### PR DESCRIPTION
PR #193 introduced a new versioning scheme that used setuptools-scm. Unfortunately, an unintended side-effect is that all files tracked in version control were added to our source distribution! The result was a ~60 MB sdist instead of the usual 110 KB sdist that we usually publish to PyPI.
Refer to https://github.com/pypa/setuptools_scm/issues/190 for more details.

This PR fixes the issue by removing setuptools-scm and implementing a new versioning scheme where the pyproject.toml file becomes the central source for version declaration