### PR TITLE
Adding option to mergeSTR to give file with list of VCFs

### DIFF
--- a/test/cmdline_tests.sh
+++ b/test/cmdline_tests.sh
@@ -179,6 +179,7 @@ echo ${FILE1} > ${TMPDIR}/vcf.list
 echo ${FILE2} >> ${TMPDIR}/vcf.list
 echo ${FILE3} >> ${TMPDIR}/vcf.list
 runcmd_pass "mergeSTR --vcfs-list ${TMPDIR}/vcf.list --out ${TMPDIR}/test_merge_hipstr_list --vcftype hipstr"
+runcmd_fail "mergeSTR --vcfs ${FILE1},${FILE2},${FILE3} --vcfs-list ${TMPDIR}/vcf.list --out ${TMPDIR}/test_merge_hipstr_list --vcftype hipstr"
 
 runcmd_pass "statSTR --vcf ${EXDATADIR}/NA12878_chr21_advntr.sorted.vcf.gz --out stdout --afreq"
 runcmd_pass "statSTR --vcf ${EXDATADIR}/NA12891_chr21_eh.sorted.vcf.gz --out ${TMPDIR}/stats_eh --numcalled"

--- a/test/cmdline_tests.sh
+++ b/test/cmdline_tests.sh
@@ -171,6 +171,15 @@ FILE2=${EXDATADIR}/NA12891_chr21_popstr.sorted.vcf.gz
 FILE3=${EXDATADIR}/NA12892_chr21_popstr.sorted.vcf.gz
 runcmd_pass "mergeSTR --vcfs ${FILE1},${FILE2},${FILE3} --out ${TMPDIR}/test_merge_popstr --vcftype popstr"
 
+# Test mergeSTR on a file with list of VCFs
+FILE1=${EXDATADIR}/NA12878_chr21_hipstr.sorted.vcf.gz
+FILE2=${EXDATADIR}/NA12891_chr21_hipstr.sorted.vcf.gz
+FILE3=${EXDATADIR}/NA12892_chr21_hipstr.sorted.vcf.gz
+echo ${FILE1} > ${TMPDIR}/vcf.list
+echo ${FILE2} >> ${TMPDIR}/vcf.list
+echo ${FILE3} >> ${TMPDIR}/vcf.list
+runcmd_pass "mergeSTR --vcfs-list ${TMPDIR}/vcf.list --out ${TMPDIR}/test_merge_hipstr_list --vcftype hipstr"
+
 runcmd_pass "statSTR --vcf ${EXDATADIR}/NA12878_chr21_advntr.sorted.vcf.gz --out stdout --afreq"
 runcmd_pass "statSTR --vcf ${EXDATADIR}/NA12891_chr21_eh.sorted.vcf.gz --out ${TMPDIR}/stats_eh --numcalled"
 runcmd_pass "statSTR --vcf ${EXDATADIR}/trio_chr21_gangstr.sorted.vcf.gz --out ${TMPDIR}/stats_gangstr --numcalled --mean"

--- a/trtools/mergeSTR/README.rst
+++ b/trtools/mergeSTR/README.rst
@@ -26,7 +26,8 @@ To run mergeSTR use the following command::
 
 Required Parameters:
 
-* :code:`--vcf <VCF>`: Comma-separated list of VCF files to merge. All must have been created by the same TR genotyper. Must be bgzipped, sorted, and indexed. (See `Instructions on Compressing and Indexing VCF files`_ below)
+* :code:`--vcfs <VCFs>`: Comma-separated list of VCF files to merge. All must have been created by the same TR genotyper. Must be bgzipped, sorted, and indexed. (See `Instructions on Compressing and Indexing VCF files`_ below)
+* :code:`--vcfs-list <FILE>`: As an alternative to :code:`--vcfs`, you can provide a file with a list of bgzipped/sorted/indexed VCF files (one filename per line) to merge. 
 * :code:`--vcftype <string>`: Type of VCF files being merged. Default = :code:`auto`. Must be one of: :code:`gangstr`, :code:`advntr`, :code:`hipstr`, :code:`eh`, :code:`popstr`.
 * :code:`--out <string>`: prefix to name output files
 

--- a/trtools/mergeSTR/mergeSTR.py
+++ b/trtools/mergeSTR/mergeSTR.py
@@ -537,7 +537,10 @@ def getargs() -> Any:  # pragma: no cover
     req_group = parser.add_argument_group("Required arguments")
     req_group.add_argument("--vcfs",
                            help="Comma-separated list of VCF files to merge (must be sorted, bgzipped and indexed)",
-                           type=str, required=True)
+                           type=str, required=False)
+    req_group.add_argument("--vcfs-list",
+                           help="File containing list of VCF files to merge. Must specify either --vcfs or --vcfs-list",
+                           type=str, required=False)
     req_group.add_argument("--out", help="Prefix to name output files", type=str, required=True)
     req_group.add_argument("--vcftype", help="Options=%s" % [str(item) for item in trh.VcfTypes.__members__], type=str,
                            default="auto")
@@ -579,7 +582,15 @@ def main(args: Any) -> int:
                        "directory".format(args.out))
         return 1
 
-    filenames = args.vcfs.split(",")
+    if args.vcfs is None and args.vcfs_list is None:
+        common.WARNING("Error: you must specify either --vcfs or --vcfs-list")
+        return 1
+
+    if args.vcfs is not None:
+        filenames = args.vcfs.split(",")
+    else:
+        filenames = [item.strip() for item in open(args.vcfs_list, "r").readlines()]
+        
     ### Check and Load VCF files ###
     vcfreaders = utils.LoadReaders(filenames, checkgz=True)
     if vcfreaders is None:

--- a/trtools/mergeSTR/mergeSTR.py
+++ b/trtools/mergeSTR/mergeSTR.py
@@ -586,6 +586,10 @@ def main(args: Any) -> int:
         common.WARNING("Error: you must specify either --vcfs or --vcfs-list")
         return 1
 
+    if args.vcfs is not None and args.vcfs_list is not None:
+        common.WARNING("Error: you cannot specify both --vcfs and --vcfs-list")
+        return 1
+
     if args.vcfs is not None:
         filenames = args.vcfs.split(",")
     else:

--- a/trtools/mergeSTR/tests/test_mergeSTR.py
+++ b/trtools/mergeSTR/tests/test_mergeSTR.py
@@ -14,6 +14,7 @@ from trtools.testsupport.utils import assert_same_vcf
 def args(tmpdir):
     args = argparse.ArgumentParser()
     args.vcfs = None
+    args.vcfs_list = None
     args.out = str(tmpdir / "test")
     args.update_sample_from_file = False 
     args.quiet = False
@@ -45,6 +46,20 @@ class DummyHarmonizedRecord:
         self.alt_alleles = alts if alts is not None else []
         self.info = info if info is not None else {}
         self.vcfrecord = DummyRecord(chrom, pos, ref, self.alt_alleles, self.info)
+
+# Test file with list of VCFs
+def test_FileList(args, mrgvcfdir, tmpdir):
+    fname1 = os.path.join(mrgvcfdir, "test_file_gangstr1.vcf.gz")
+    fname2 = os.path.join(mrgvcfdir, "test_file_gangstr2.vcf.gz")
+    args.vcftype = "gangstr"
+    listfile = str(tmpdir / "test.list")
+    f = open(listfile, "w")
+    f.write(fname1+"\n")
+    f.write(fname2+"\n")
+    f.close()
+    args.vcfs_list = listfile
+    args.vcfs = None
+    assert main(args)==0
 
 # Test right files or directory - GangSTR
 def test_GangSTRRightFile(args, mrgvcfdir):


### PR DESCRIPTION
Currently mergeSTR requires the argument `--vcf` which takes a comma-separated list of VCF files to merge. When running mergeSTR on a large number of files, this results in very long commands. This PR adds the option `--vcfs-list` to mergeSTR as an alternative which allows users to specify a file with a list of the VCFs to merge (one file per line).