### PR TITLE
fix: deprecation of binom_test in scipy 1.12.0 and cryptic error occurring with incorrect VCFs in cyvcf2 0.30.26

### DIFF
--- a/trtools/dumpSTR/dumpSTR.py
+++ b/trtools/dumpSTR/dumpSTR.py
@@ -1201,6 +1201,13 @@ def main(args):
                 return 1
             else:
                 raise te
+        except ValueError as ve:
+            message = ve.args[0]
+            if 'properly formatted' in message:
+                common.WARNING("Could not parse VCF.\n" + message)
+                return 1
+            else:
+                raise ve
         if args.verbose:
             common.MSG("Processing %s:%s"%(record.chrom, record.pos))
         record_counter += 1

--- a/trtools/qcSTR/qcSTR.py
+++ b/trtools/qcSTR/qcSTR.py
@@ -501,7 +501,24 @@ def main(args):
 
     # read the vcf
     numrecords = 0
-    for trrecord in harmonizer:
+    while True:
+        try:
+            trrecord = next(harmonizer)
+        except StopIteration: break
+        except TypeError as te:
+            message = te.args[0]
+            if 'missing' in message and 'mandatory' in message:
+                common.WARNING("Could not parse VCF.\n" + message)
+                return 1
+            else:
+                raise te
+        except ValueError as ve:
+            message = ve.args[0]
+            if 'properly formatted' in message:
+                common.WARNING("Could not parse VCF.\n" + message)
+                return 1
+            else:
+                raise ve
         if args.numrecords is not None and numrecords >= args.numrecords: break
         if args.period is not None and len(trrecord.motif) != args.period: continue
 

--- a/trtools/utils/tr_harmonizer.py
+++ b/trtools/utils/tr_harmonizer.py
@@ -1544,6 +1544,7 @@ class TRRecordHarmonizer:
     def __init__(self, vcffile: cyvcf2.VCF, vcftype: Union[str, VcfTypes] = "auto"):
         self.vcffile = vcffile
         self.vcftype = InferVCFType(vcffile, vcftype)
+        self._record_idx = None
 
     def MayHaveImpureRepeats(self) -> bool:
         """
@@ -1619,6 +1620,16 @@ class TRRecordHarmonizer:
 
     def __next__(self) -> TRRecord:
         """Iterate over TRRecord produced from the underlying vcf."""
-        return HarmonizeRecord(self.vcftype, next(self.vcffile))
+        if self._record_idx is None:
+            self._record_idx = 1
+        self._record_idx += 1
+        try:
+            record = next(self.vcffile)
+        except Exception:
+            raise ValueError(
+                f"Encountered error when parsing the {self._record_idx}th tandem "
+                "repeat in the provided VCF. Check that it is properly formatted."
+            )
+        return HarmonizeRecord(self.vcftype, record)
 
 # TODO check all users of this class for new options

--- a/trtools/utils/tr_harmonizer.py
+++ b/trtools/utils/tr_harmonizer.py
@@ -1625,9 +1625,11 @@ class TRRecordHarmonizer:
         self._record_idx += 1
         try:
             record = next(self.vcffile)
+        except StopIteration:
+            raise
         except Exception:
             raise ValueError(
-                f"Encountered error when parsing the {self._record_idx}th tandem "
+                f"Unable to parse the {self._record_idx}th tandem "
                 "repeat in the provided VCF. Check that it is properly formatted."
             )
         return HarmonizeRecord(self.vcftype, record)

--- a/trtools/utils/tr_harmonizer.py
+++ b/trtools/utils/tr_harmonizer.py
@@ -1629,7 +1629,7 @@ class TRRecordHarmonizer:
             raise
         except Exception:
             raise ValueError(
-                f"Unable to parse the {self._record_idx}th tandem "
+                "Unable to parse the "+str(self._record_idx)+"th tandem "
                 "repeat in the provided VCF. Check that it is properly formatted."
             )
         return HarmonizeRecord(self.vcftype, record)

--- a/trtools/utils/utils.py
+++ b/trtools/utils/utils.py
@@ -318,7 +318,11 @@ def GetHardyWeinbergBinomialTest(allele_freqs, genotype_counts):
         if gt[1] not in allele_freqs.keys():
             return np.nan
         if gt[0] == gt[1]: num_hom += genotype_counts[gt]
-    return scipy.stats.binom_test(num_hom, n=total_samples, p=exp_hom_frac)
+    try:
+        return scipy.stats.binom_test(num_hom, n=total_samples, p=exp_hom_frac)
+    except AttributeError:
+        # binom_test was deprecated in favor of binomtest in scipy 1.12.0
+        return scipy.stats.binomtest(num_hom, n=total_samples, p=exp_hom_frac).pvalue
 
 def GetHomopolymerRun(seq):
     r"""Compute the maximum homopolymer run length in a sequence


### PR DESCRIPTION
This PR handles errors that arise when you upgrade to the newest versions of our dependencies, specifically for cyvcf2 and scipy

It resolves #206 and also handles the deprecation of `scipy.stats.binom_test` in favor of `scipy.stats.binomtest`: https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html#expired-deprecations

Merging this PR will resolve failures in the CI checks for all of our other PRs