### PR TITLE
fix: clone command in `test_trtools.sh` testing script

### DIFF
--- a/test/cmdline_tests.sh
+++ b/test/cmdline_tests.sh
@@ -25,13 +25,15 @@ if [ $# -eq 0 ]; then
     # use default example location
     EXDATADIR="example-files"
     BEAGLEDIR="trtools/testsupport/sample_vcfs/beagle"
-elif (( $# != 2 )) ; then
-    echo "usage: cmdline_tests.sh {example_dir} {beagle_dir}" 2>&1
-    echo "Expected 2 arguments but recieved $#" 2>&1
+    BEAGLESCRIPT="scripts/trtools_prep_beagle_vcf.sh"
+elif (( $# != 3 )) ; then
+    echo "usage: cmdline_tests.sh {example_dir} {beagle_dir} {beagle_script}" 2>&1
+    echo "Expected 3 arguments but recieved $#" 2>&1
     exit 1
 else
     EXDATADIR=$1
     BEAGLEDIR=$2
+    BEAGLESCRIPT=$3
 fi
 
 TMPDIR=$(mktemp -d -t tmp-XXXXXXXXXX)
@@ -220,10 +222,10 @@ prep_beagle_out="$TMPDIR"/test_prep_beagle_vcf.vcf.gz
 ref_panel="$BEAGLEDIR"/1kg_snpstr_21_first_100k_first_50_annotated.vcf.gz
 imputed_vcf="$BEAGLEDIR"/1kg_snpstr_21_first_100k_second_50_STRs_imputed.vcf.gz
 
-runcmd_fail "trtools_prep_beagle_vcf.sh hipstr nonexistent.vcf.gz $imputed_vcf $prep_beagle_out"
-runcmd_fail "trtools_prep_beagle_vcf.sh hipstr $ref_panel nonexistent.vcf.gz $prep_beagle_out"
+runcmd_fail "$BEAGLESCRIPT hipstr nonexistent.vcf.gz $imputed_vcf $prep_beagle_out"
+runcmd_fail "$BEAGLESCRIPT hipstr $ref_panel nonexistent.vcf.gz $prep_beagle_out"
 
-trtools_prep_beagle_vcf.sh hipstr "$ref_panel" "$imputed_vcf" "$prep_beagle_out"
+$BEAGLESCRIPT hipstr "$ref_panel" "$imputed_vcf" "$prep_beagle_out"
 
 if ! [[ -f "$prep_beagle_out" ]] ; then
     echo "prep_beagle_vcf test didn't produce output file" >&2

--- a/trtools/testsupport/test_trtools.sh
+++ b/trtools/testsupport/test_trtools.sh
@@ -2,13 +2,13 @@
 
 # Run the tests for an installed copy of trtools
 # If not already present, megabytes of test data will be downloaded before test running
+# Please note that this script tests TRTools against
+# test files committed to the repo and will miss any local changes to those files
 
 # If TRTools was installed normally, this script can be executed by simply running
 # 'test_trtools.sh' on the command line.
 # Otherwise, if TRTools was installed via poetry, you should run the command
-# 'poetry run trtools/testsupport/test_trtools.sh'. However, please note that this
-# script should not be used to test TRTools against any recent/unpublished changes.
-
+# 'poetry run trtools/testsupport/test_trtools.sh'.
 echo "Running test_trtools.sh"
 
 command -v git >/dev/null 2>&1 || { echo >&2 "git is not available, but is required for downloading the test data. Aborting."; exit 1; }

--- a/trtools/testsupport/test_trtools.sh
+++ b/trtools/testsupport/test_trtools.sh
@@ -3,7 +3,7 @@
 # Run the tests for an installed copy of trtools
 # If not already present, megabytes of test data will be downloaded before test running
 # Please note that this script tests TRTools against
-# test files committed to the repo and will miss any local changes to those files
+# test files from a published release and will miss any local changes to those files
 
 # If TRTools was installed normally, this script can be executed by simply running
 # 'test_trtools.sh' on the command line.

--- a/trtools/testsupport/test_trtools.sh
+++ b/trtools/testsupport/test_trtools.sh
@@ -15,7 +15,7 @@ if [ ! -d "$TMP" ] ; then
 	echo "Downloading test data ..."
 	mkdir $TMP
 	pushd $TMP
-	git clone -b v$(dumpSTR --version) https://github.com/gymrek-lab/TRTools.git
+	git clone -b v$(dumpSTR --version) https://github.com/gymrek-lab/TRTools.git .
 	popd
 	echo "Download done"
 else

--- a/trtools/testsupport/test_trtools.sh
+++ b/trtools/testsupport/test_trtools.sh
@@ -3,6 +3,12 @@
 # Run the tests for an installed copy of trtools
 # If not already present, megabytes of test data will be downloaded before test running
 
+# If TRTools was installed normally, this script can be executed by simply running
+# 'test_trtools.sh' on the command line.
+# Otherwise, if TRTools was installed via poetry, you should run the command
+# 'poetry run trtools/testsupport/test_trtools.sh'. However, please note that this
+# script should not be used to test TRTools against any recent/unpublished changes.
+
 echo "Running test_trtools.sh"
 
 command -v git >/dev/null 2>&1 || { echo >&2 "git is not available, but is required for downloading the test data. Aborting."; exit 1; }
@@ -41,4 +47,4 @@ cd "$loc" || exit 1
 # run unit tests
 python -m pytest . -p trtools.testsupport.dataloader --datadir "$TMP"/trtools/testsupport
 # run command line tests
-$TMP/test/cmdline_tests.sh $TMP/example-files $TMP/trtools/testsupport/sample_vcfs/beagle
+$TMP/test/cmdline_tests.sh $TMP/example-files $TMP/trtools/testsupport/sample_vcfs/beagle $TMP/scripts/trtools_prep_beagle_vcf.sh


### PR DESCRIPTION
This fixes a mistake I made in b23fa5635f7a10f871e57b6d08640f7a9025fcbc (in PR #202). I forgot to clone into the _current_ directory and only realized when the bioconda test failed in https://github.com/bioconda/bioconda-recipes/pull/45894#issuecomment-1953220461. We managed to patch the bioconda recipe, but anyone who tries to run the `test_trtools.sh` script after installing TRTools 6.0.0 with pip will still run into an error. This PR fixes that error for the next release of TRTools.

**Update (2/20):** I also added commit 37c75bb to ensure the `test_trtools.sh` script can be executed locally in a development installation of TRTools. Of course, this should only be used to test that the `test_trtools.sh` script itself is working. It won't actually test TRTools properly because it will use an outdated version of our test and data files.