### PR TITLE
ci: fix broken GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
-          - { python: "3.8", os: "macos-latest", session: "tests" }
+          - { python: "3.8", os: "macos-13", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "size" }
           - { python: "3.8", os: "ubuntu-latest", session: "coverage" }
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,12 +15,12 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --only main,docs
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only main,docs
 
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
Our pull request checks broke because of https://github.com/readthedocs/readthedocs.org/issues/11150 and https://github.com/actions/runner-images/issues/9741 ! Let's fix them