### PR TITLE
docs: warn about scipy deprecation in dumpSTR

### DIFF
--- a/trtools/dumpSTR/README.rst
+++ b/trtools/dumpSTR/README.rst
@@ -37,6 +37,9 @@ The available filters are described below.
 
 See `Example Commands`_ for running dumpSTR on different supported TR genotypers using example VCFs in this repository.
 
+.. warning::
+  Please note that there is an incompatibility with :code:`dumpSTR<6.0.0` and :code:`scipy>1.12.0`. Please update to a newer version of TRTools if you encounter an error indicating that :code:`scipy.stats.binom_test` has been deprecated.
+
 Filter options
 --------------
 

--- a/trtools/dumpSTR/README.rst
+++ b/trtools/dumpSTR/README.rst
@@ -38,7 +38,7 @@ The available filters are described below.
 See `Example Commands`_ for running dumpSTR on different supported TR genotypers using example VCFs in this repository.
 
 .. warning::
-  Please note that there is an incompatibility with :code:`dumpSTR<6.0.0` and :code:`scipy>1.12.0`. Please update to a newer version of TRTools if you encounter an error indicating that :code:`scipy.stats.binom_test` has been deprecated.
+  :code:`dumpSTR<6.0.0` and :code:`scipy>=1.12.0` are incompatible. You should update to a newer version of TRTools if you encounter an error indicating that :code:`scipy.stats.binom_test` has been deprecated.
 
 Filter options
 --------------


### PR DESCRIPTION
The deprecation was handled in https://github.com/gymrek-lab/TRTools/pull/208 but it might still be worth it to warn about it in the docs. Thanks @aarushi03 for pointing this out!