### PR TITLE
fix: enable filter_hrun with beagle file in dumpSTR

### DIFF
--- a/trtools/dumpSTR/dumpSTR.py
+++ b/trtools/dumpSTR/dumpSTR.py
@@ -89,9 +89,6 @@ def CheckLocusFilters(args, vcftype, is_beagle: bool):
         common.WARNING("--use-length is only meaningful for HipSTR, which reports sequence level differences.")
     if args.filter_hrun and vcftype not in [trh.VcfTypes["hipstr"]]:
         common.WARNING("--filter-hrun only relevant to HipSTR files. This filter will have no effect.")
-    if args.filter_hrun and is_beagle:
-        common.WARNING("--filter-hrun cannot be applied to Beagle imputed files")
-        return False
     if args.filter_regions is not None:
         if args.filter_regions_names is not None:
             filter_region_files = args.filter_regions.split(",")

--- a/trtools/dumpSTR/tests/test_dumpSTR.py
+++ b/trtools/dumpSTR/tests/test_dumpSTR.py
@@ -514,7 +514,7 @@ def test_beagle_disallowed_locus_filters(tmpdir, vcfdir):
     args_obj = args(tmpdir)
     args_obj.vcf = os.path.join(vcfdir, 'beagle/hipstr_imputed.vcf.gz')
     args_obj.filter_hrun = True
-    assert main(args_obj) == 1
+    assert main(args_obj) == 0
 
 def test_beagle_disallowed_call_filters(tmpdir, vcfdir):
     args_obj = args(tmpdir)


### PR DESCRIPTION
This PR enables Beagle imputed files to run with filter_hrun in dumpSTR.

Deleted the section in dumpSTR that checks is_beagle and filter_hrun. Updated the test case accordingly.


## Checklist

* [x] I've checked to ensure there aren't already other open [pull requests](../../../pulls) for the same update/change
* [x] I've prefixed the title of my PR according to [the conventional commits specification](https://www.conventionalcommits.org/). If your PR fixes a bug, please prefix the PR with `fix: `. Otherwise, if it introduces a new feature, please prefix it with `feat: `. If it introduces a breaking change, please add an exclamation before the colon, like `feat!: `. If the scope of the PR changes because of a revision to it, please update the PR title, since the title will be used in our CHANGELOG.
* [ ] (NA) At the top of the PR, I've [listed any open issues that this PR will resolve](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). For example, "resolves #0" if this PR resolves issue #0
- [x] I've explained my changes in a manner that will make it possible for both users and maintainers of TRTools to understand them
* [x] I've added tests for any new functionality. Or, if this PR fixes a bug, I've added test(s) that replicate it
* [ ] (NA) All directories with large test files are listed in [the "exclude" section](https://python-poetry.org/docs/pyproject/#include-and-exclude) of our pyproject.toml so that they do not appear in our PyPI distribution. All new files are also smaller than 0.5 MB.
* [ ] (NA) I've updated the relevant REAMDEs with any new usage information and checked that the newly built documentation is formatted properly
* [ ] (NA) All functions, modules, classes etc. still conform to [numpy docstring standards](https://numpydoc.readthedocs.io/en/latest/format.html)
* [ ] (if applicable) I've updated the pyproject.toml file with any changes I've made to TRTools's dependencies, and I've run `poetry lock --no-update` to ensure the lock file stays up to date and that our dependencies are locked to their minimum versions
* [x] In the body of this PR, I've included a short address to the reviewer highlighting one or two items that might deserve their focus