### PR TITLE
fix: bug in beagle dosages with no alt alleles

### DIFF
--- a/trtools/utils/tests/test_trharmonizer.py
+++ b/trtools/utils/tests/test_trharmonizer.py
@@ -97,6 +97,18 @@ def get_dummy_record_gts_allsamelen():
         alt=["CAGCAACAG"]
     )
 
+dummy_record_gts_monomorphic = [
+    [0, 0],
+    [0, 0],
+    [0, 0],
+    [0, 0]]
+def get_dummy_record_gts_monomorphic():
+    return DummyCyvcf2Record(
+        gts=dummy_record_gts_monomorphic,
+        ref="CAGCAGCAG",
+        alt=[]
+    )
+
 triploid_gts = np.array([
     [0, 0, -2],
     [0, 0, -2],
@@ -340,6 +352,17 @@ def test_TRRecord_GetGenotypes_Dosages():
     true_beagle_norm_dosages = np.array([0, 0, 0, 0])
     assert np.all(rec.GetDosages(dosagetype=trh.TRDosageTypes.beagleap_norm) ==
         true_beagle_norm_dosages)
+
+    monomorphic_record = get_dummy_record_gts_monomorphic()
+    monomorphic_record.FORMAT["AP1"] = np.array([[]])
+    monomorphic_record.FORMAT["AP2"] = np.array([[]])
+    rec = trh.TRRecord(monomorphic_record, monomorphic_record.REF, [], "CAG", "", None)
+    true_bestguess_norm_dosages = np.array([0, 0, 0, 0], dtype=np.float32)
+    assert np.all(rec.GetDosages(dosagetype=trh.TRDosageTypes.bestguess_norm) ==
+        true_bestguess_norm_dosages)
+    true_beagleap_dosages = np.array([6, 6, 6, 6], dtype=np.float32)
+    assert np.all(rec.GetDosages(dosagetype=trh.TRDosageTypes.beagleap) ==
+        true_beagleap_dosages)
 
     # Test regular diploid record - Example with bestguess same as AP-based dosage
     diploid_record = get_dummy_record_diploid()

--- a/trtools/utils/tr_harmonizer.py
+++ b/trtools/utils/tr_harmonizer.py
@@ -1146,9 +1146,13 @@ class TRRecord:
                 raise ValueError("Negative AP1 or AP2 fields detected")
 
             # Get haplotype dosages
-            max_alt_len = max(self.alt_allele_lengths)
-            h1_dos = np.clip(np.dot(ap1, self.alt_allele_lengths), 0, max_alt_len)
-            h2_dos = np.clip(np.dot(ap2, self.alt_allele_lengths), 0, max_alt_len)
+            if len(self.alt_allele_lengths) > 0:
+                max_alt_len = max(self.alt_allele_lengths)
+                h1_dos = np.clip(np.dot(ap1, self.alt_allele_lengths), 0, max_alt_len)
+                h2_dos = np.clip(np.dot(ap2, self.alt_allele_lengths), 0, max_alt_len)
+            else:
+                h1_dos = 0
+                h2_dos = 0
             ref1_dos = ref1*self.ref_allele_length
             ref2_dos = ref2*self.ref_allele_length
 


### PR DESCRIPTION
This solves one of the issues in #209 regarding computing beagle dosages on monomorphic loci. However there are other points in that issue that still need resolving so let's leave it open for now.

## Checklist

* [x ] I've checked to ensure there aren't already other open [pull requests](../../../pulls) for the same update/change
* [ x] I've prefixed the title of my PR according to [the conventional commits specification](https://www.conventionalcommits.org/). If your PR fixes a bug, please prefix the PR with `fix: `. Otherwise, if it introduces a new feature, please prefix it with `feat: `. If it introduces a breaking change, please add an exclamation before the colon, like `feat!: `. If the scope of the PR changes because of a revision to it, please update the PR title, since the title will be used in our CHANGELOG.
* [ x] At the top of the PR, I've [listed any open issues that this PR will resolve](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). For example, "resolves #0" if this PR resolves issue #0
- [x ] I've explained my changes in a manner that will make it possible for both users and maintainers of TRTools to understand them
* [x ] I've added tests for any new functionality. Or, if this PR fixes a bug, I've added test(s) that replicate it
* [x ] All directories with large test files are listed in [the "exclude" section](https://python-poetry.org/docs/pyproject/#include-and-exclude) of our pyproject.toml so that they do not appear in our PyPI distribution. All new files are also smaller than 0.5 MB.
* [ x] I've updated the relevant REAMDEs with any new usage information and checked that the newly built documentation is formatted properly
* [ x] All functions, modules, classes etc. still conform to [numpy docstring standards](https://numpydoc.readthedocs.io/en/latest/format.html)
* [x ] (if applicable) I've updated the pyproject.toml file with any changes I've made to TRTools's dependencies, and I've run `poetry lock --no-update` to ensure the lock file stays up to date and that our dependencies are locked to their minimum versions
* [ x] In the body of this PR, I've included a short address to the reviewer highlighting one or two items that might deserve their focus
