### PR TITLE
fix: allow for IUPAC codes in `GetCanonicalMotif()`

### DIFF
--- a/trtools/utils/tests/test_utils.py
+++ b/trtools/utils/tests/test_utils.py
@@ -115,6 +115,8 @@ def test_GetCanonicalMotif():
     assert(utils.GetCanonicalMotif("TTGTT")=="AAAAC")
     assert(utils.GetCanonicalMotif("")=="")
     assert(utils.GetCanonicalMotif("cag")=="AGC")
+    assert(utils.GetCanonicalMotif("AARRG")=="AARRG")
+    assert(utils.GetCanonicalMotif("YARRG")=="ARRGY")
 
 # GetCanonicalOneStrand
 def test_GetCanonicalOneStrand():

--- a/trtools/utils/utils.py
+++ b/trtools/utils/utils.py
@@ -14,7 +14,6 @@ import scipy.stats
 
 import trtools.utils.common as common # pragma: no cover
 
-nucToNumber={"A":0,"C":1,"G":2,"T":3}
 
 def LoadSingleReader(
         vcf_loc: str,

--- a/trtools/utils/utils.py
+++ b/trtools/utils/utils.py
@@ -387,9 +387,9 @@ def GetCanonicalMotif(repseq):
     repseq_r = GetCanonicalOneStrand(ReverseComplement(repseq))
     # choose first seq alphabetically
     for i in range(len(repseq_f)):
-        if nucToNumber[repseq_f[i]] < nucToNumber[repseq_r[i]]:
+        if repseq_f[i] < repseq_r[i]:
             return repseq_f
-        if nucToNumber[repseq_r[i]] < nucToNumber[repseq_f[i]]:
+        if repseq_r[i] < repseq_f[i]:
             return repseq_r
     return repseq_f
 
@@ -420,9 +420,9 @@ def GetCanonicalOneStrand(repseq):
     for i in range(size):
         newseq = repseq[size-i:]+repseq[0:size-i]
         for j in range(size):
-            if nucToNumber[newseq[j]] < nucToNumber[canonical[j]]:
+            if newseq[j] < canonical[j]:
                 canonical = newseq
-            elif nucToNumber[newseq[j]] > nucToNumber[canonical[j]]:
+            elif newseq[j] > canonical[j]:
                 break
     return canonical
 


### PR DESCRIPTION
partially addresses #238 

This will allow TRTools's `GetCanonicalMotif()` to work for sequences that have IUPAC codes. However, this will not entirely solve the problem described in #238, since any function that calls `GetCanonicalMotif()` will now have to handle the IUPAC codes somehow.